### PR TITLE
Add Access-Control-Allow-Methods header to HTTP responses

### DIFF
--- a/src/main/java/com/buddycloud/mediaserver/web/MediaResource.java
+++ b/src/main/java/com/buddycloud/mediaserver/web/MediaResource.java
@@ -45,7 +45,7 @@ public class MediaResource extends MediaServerResource {
 
 	@Put
 	public Representation putAvatar(Representation entity) {
-		addCORSHeader();
+		addCORSHeaders();
 		
 		String auth = getQueryValue(Constants.AUTH_QUERY);
 		Request request = getRequest();
@@ -122,7 +122,7 @@ public class MediaResource extends MediaServerResource {
 
 	@Delete
 	public Representation deleteMedia() {
-		addCORSHeader();
+		addCORSHeaders();
 		
 		String auth = getQueryValue(Constants.AUTH_QUERY);
 		Request request = getRequest();
@@ -180,7 +180,7 @@ public class MediaResource extends MediaServerResource {
 
 	@Post
 	public Representation updateMedia(Representation entity) {
-		addCORSHeader();
+		addCORSHeaders();
 		
 		String auth = getQueryValue(Constants.AUTH_QUERY);
 		Request request = getRequest();
@@ -257,7 +257,7 @@ public class MediaResource extends MediaServerResource {
 
 	@Get
 	public Representation getMedia() {
-		addCORSHeader();
+		addCORSHeaders();
 		
 		Request request = getRequest();
 

--- a/src/main/java/com/buddycloud/mediaserver/web/MediaServerResource.java
+++ b/src/main/java/com/buddycloud/mediaserver/web/MediaServerResource.java
@@ -37,7 +37,8 @@ import com.buddycloud.mediaserver.xmpp.XMPPToolBox;
 public abstract class MediaServerResource extends ServerResource {
 
 	protected static final String HEADERS_KEY = "org.restlet.http.headers";
-	protected static final String CORS_HEADER = "Access-Control-Allow-Origin";
+	protected static final String CORS_ORIGIN_HEADER = "Access-Control-Allow-Origin";
+	protected static final String CORS_METHODS_HEADER = "Access-Control-Allow-Methods";
 	protected static final String AUTH_SEPARATOR = ":";
 	
 
@@ -65,8 +66,9 @@ public abstract class MediaServerResource extends ServerResource {
         return headers;
     }
 	
-	protected void addCORSHeader() {
-		getMessageHeaders(getResponse()).add(CORS_HEADER, "*");
+	protected void addCORSHeaders() {
+		getMessageHeaders(getResponse()).add(CORS_ORIGIN_HEADER, "*");
+		getMessageHeaders(getResponse()).add(CORS_METHODS_HEADER, "GET, POST, PUT, DELETE");
 	}
 
 	protected Representation authenticationResponse() {

--- a/src/main/java/com/buddycloud/mediaserver/web/MediasResource.java
+++ b/src/main/java/com/buddycloud/mediaserver/web/MediasResource.java
@@ -36,7 +36,7 @@ public class MediasResource extends MediaServerResource {
 
 	@Post
 	public Representation postMedia(Representation entity) {
-		addCORSHeader();
+		addCORSHeaders();
 		
 		String auth = getQueryValue(Constants.AUTH_QUERY);
 		Request request = getRequest();
@@ -107,7 +107,7 @@ public class MediasResource extends MediaServerResource {
 
 	@Get
 	public Representation getMediasInfo() {
-		addCORSHeader();
+		addCORSHeaders();
 		
 		Request request = getRequest();
 


### PR DESCRIPTION
Without the CORS Access-Control-Allow-Methods header, the media server does not allow cross-origin POST, PUT or DELETE requests. This branch adds the header.
