### PR TITLE
Maven fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,14 +97,14 @@
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>
 			<artifactId>smack</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.1-MODIFIED</version>
 			<scope>system</scope>
 			<systemPath>${project.basedir}/lib/smack.jar</systemPath>
 		</dependency>
 		<dependency>
 			<groupId>org.igniterealtime.smack</groupId>
 			<artifactId>smackx</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.1-MODIFIED</version>
 			<scope>system</scope>
 			<systemPath>${project.basedir}/lib/smackx.jar</systemPath>
 		</dependency>


### PR DESCRIPTION
These changes make "mediaserver" the default profile and add missing local dependencies in `lib/`. It also changes the default settings to skip tests by default.
