### PR TITLE
Create a JAR with no version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,34 @@
 				    </descriptorRefs>
                 </configuration>
             </plugin>
+            <plugin>
+                  <groupId>com.github.goldin</groupId>
+                  <artifactId>copy-maven-plugin</artifactId>
+                  <version>0.2.5</version>
+                  <executions>
+                    <execution>
+                      <id>create-archive</id>
+                      <phase>package</phase>
+                      <goals>
+                        <goal>copy</goal>
+                      </goals>
+                      <configuration>
+                        <resources>
+                          <resource>
+                            <targetPath>${project.build.directory}</targetPath>
+                            <file>target/${project.build.finalName}.jar</file>
+                            <destFileName>${project.artifactId}.jar</destFileName>
+                          </resource>
+                          <resource>
+                            <targetPath>${project.build.directory}</targetPath>
+                            <file>${project.build.directory}/${project.build.finalName}-${project.build.withDependencies}.jar</file>
+                            <destFileName>${project.artifactId}-${project.build.withDependencies}.jar</destFileName>
+                          </resource>
+                        </resources>
+                      </configuration>
+                    </execution>
+                  </executions>
+                </plugin>
             <!-- Jetty -->
             <plugin>
                 <groupId>org.mortbay.jetty</groupId>
@@ -287,6 +315,7 @@
     </build>
     <properties>
         <restlet-version>2.2-M6</restlet-version>
+        <project.build.withDependencies>jar-with-dependencies</project.build.withDependencies>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <repositories>
@@ -300,5 +329,12 @@
             <url>http://xuggle.googlecode.com/svn/trunk/repo/share/java/</url>
         </repository>
     </repositories>
+    <pluginRepositories>
+      <pluginRepository>
+        <id>evgenyg</id>
+        <name>Evgeny Goldin repo</name>
+        <url>http://evgenyg.artifactoryonline.com/evgenyg/repo/com/github/goldin/</url>
+      </pluginRepository>
+    </pluginRepositories>
 </project>
 


### PR DESCRIPTION
Just like the main buddycloud server. Makes deployment easier.
Also outputs versioned JAR too.
