### PR TITLE
If not configuration value set, choose sensible default, don't crash!

### DIFF
--- a/src/main/java/com/buddycloud/mediaserver/Main.java
+++ b/src/main/java/com/buddycloud/mediaserver/Main.java
@@ -112,7 +112,7 @@ public class Main {
 	}
 
     private static void setXMPPReplyTimeout(Properties configuration) {
-        int xmppReplyTimeout = Integer.valueOf(configuration.getProperty(MediaServerConfiguration.XMPP_REPLY_TIMEOUT));
+        int xmppReplyTimeout = Integer.valueOf(configuration.getProperty(MediaServerConfiguration.XMPP_REPLY_TIMEOUT), 60);
         SmackConfiguration.setPacketReplyTimeout(xmppReplyTimeout);
     }
 


### PR DESCRIPTION
```
13:35:54.639 [main] INFO  com.buddycloud.mediaserver.Main - Buddycloud Media Server HTTP server started!
13:35:54.645 [main] ERROR com.buddycloud.mediaserver.Main - Error while starting XMPP client / component
java.lang.NumberFormatException: null
    at java.lang.Integer.parseInt(Integer.java:417) ~[na:1.6.0_26]
    at java.lang.Integer.valueOf(Integer.java:554) ~[na:1.6.0_26]
    at com.buddycloud.mediaserver.Main.setXMPPReplyTimeout(Main.java:115) ~[buddycloud-media-server-jar-with-dependencies.jar:na]
    at com.buddycloud.mediaserver.Main.startXMPPToolBox(Main.java:120) ~[buddycloud-media-server-jar-with-dependencies.jar:na]
    at com.buddycloud.mediaserver.Main.main(Main.java:52) ~[buddycloud-media-server-jar-with-dependencies.jar:na]
```
